### PR TITLE
Support secure grpc connection using MTLS

### DIFF
--- a/src/clp_notification_monitor/main.py
+++ b/src/clp_notification_monitor/main.py
@@ -15,7 +15,10 @@ import pymongo
 
 from clp_notification_monitor.compression_buffer.compression_buffer import CompressionBuffer
 from clp_notification_monitor.seaweedfs_monitor.notification_message import S3NotificationMessage
-from clp_notification_monitor.seaweedfs_monitor.seaweedfs_grpc_client import SeaweedFSClient, MTLSConfig
+from clp_notification_monitor.seaweedfs_monitor.seaweedfs_grpc_client import (
+    MTLSConfig,
+    SeaweedFSClient,
+)
 
 """
 Global logger
@@ -197,7 +200,7 @@ def main(argv: List[str]) -> int:
     parser.add_argument(
         "--grpc-secure",
         required=False,
-        action='store_true',
+        action="store_true",
         help="The grpc connection must be secure.",
     )
     parser.add_argument(
@@ -262,11 +265,21 @@ def main(argv: List[str]) -> int:
     if mtls_conf.Secure:
         if None in [args.mtls_chain_path, args.mtls_private_path, args.mtls_server_path]:
             parser.error("mtls cert paths is required with --grpc-secure.")
-        mtls_conf.ChainPath, mtls_conf.PrivateKeyPath, mtls_conf.ServerPath = map(Path, [args.mtls_chain_path, args.mtls_private_path, args.mtls_server_path])
+        mtls_conf.ChainPath, mtls_conf.PrivateKeyPath, mtls_conf.ServerPath = map(
+            Path, [args.mtls_chain_path, args.mtls_private_path, args.mtls_server_path]
+        )
         mtls_conf.SSLTargetOverride = args.mtls_target_override
-        if False in [mtls_conf.ChainPath.is_absolute(), mtls_conf.PrivateKeyPath.is_absolute(), mtls_conf.ServerPath.is_absolute()]:
+        if False in [
+            mtls_conf.ChainPath.is_absolute(),
+            mtls_conf.PrivateKeyPath.is_absolute(),
+            mtls_conf.ServerPath.is_absolute(),
+        ]:
             parser.error("mtls cert paths must be absolute.")
-        if False in [mtls_conf.ChainPath.is_file(), mtls_conf.PrivateKeyPath.is_file(), mtls_conf.ServerPath.is_file()]:
+        if False in [
+            mtls_conf.ChainPath.is_file(),
+            mtls_conf.PrivateKeyPath.is_file(),
+            mtls_conf.ServerPath.is_file(),
+        ]:
             parser.error("mtls cert paths must exist.")
 
     seaweedfs_client: SeaweedFSClient

--- a/src/clp_notification_monitor/main.py
+++ b/src/clp_notification_monitor/main.py
@@ -15,7 +15,7 @@ import pymongo
 
 from clp_notification_monitor.compression_buffer.compression_buffer import CompressionBuffer
 from clp_notification_monitor.seaweedfs_monitor.notification_message import S3NotificationMessage
-from clp_notification_monitor.seaweedfs_monitor.seaweedfs_grpc_client import SeaweedFSClient
+from clp_notification_monitor.seaweedfs_monitor.seaweedfs_grpc_client import SeaweedFSClient, MTLSConfig
 
 """
 Global logger
@@ -194,6 +194,37 @@ def main(argv: List[str]) -> int:
             " trigger period in milliseconds."
         ),
     )
+    parser.add_argument(
+        "--grpc-secure",
+        required=False,
+        action='store_true',
+        help="The grpc connection must be secure.",
+    )
+    parser.add_argument(
+        "--mtls_chain_path",
+        required=False,
+        type=str,
+        help="The path of grpc mtls chain cert",
+    )
+    parser.add_argument(
+        "--mtls_private_path",
+        required=False,
+        type=str,
+        help="The path of grpc mtls private cert",
+    )
+    parser.add_argument(
+        "--mtls_server_path",
+        required=False,
+        type=str,
+        help="The path of grpc mtls server cert",
+    )
+    parser.add_argument(
+        "--mtls_target_override",
+        required=False,
+        type=str,
+        default="",
+        help="The server name override in mtls cert",
+    )
 
     input_type_parser: argparse._SubParsersAction = parser.add_subparsers(dest="input_type")
     input_type_parser.required = True
@@ -226,12 +257,24 @@ def main(argv: List[str]) -> int:
         if not seaweed_mnt_prefix.is_absolute():
             parser.error("--seaweed-mnt-prefix must be absolute.")
 
+    mtls_conf: MTLSConfig = MTLSConfig()
+    mtls_conf.Secure = args.grpc_secure
+    if mtls_conf.Secure:
+        if None in [args.mtls_chain_path, args.mtls_private_path, args.mtls_server_path]:
+            parser.error("mtls cert paths is required with --grpc-secure.")
+        mtls_conf.ChainPath, mtls_conf.PrivateKeyPath, mtls_conf.ServerPath = map(Path, [args.mtls_chain_path, args.mtls_private_path, args.mtls_server_path])
+        mtls_conf.SSLTargetOverride = args.mtls_target_override
+        if False in [mtls_conf.ChainPath.is_absolute(), mtls_conf.PrivateKeyPath.is_absolute(), mtls_conf.ServerPath.is_absolute()]:
+            parser.error("mtls cert paths must be absolute.")
+        if False in [mtls_conf.ChainPath.is_file(), mtls_conf.PrivateKeyPath.is_file(), mtls_conf.ServerPath.is_file()]:
+            parser.error("mtls cert paths must exist.")
+
     seaweedfs_client: SeaweedFSClient
     db_client: pymongo.mongo_client.MongoClient  # type: ignore
 
     logger.info("Initiating SeaweedFS and MongoDB clients.")
     # fmt: off
-    with closing(SeaweedFSClient("clp—user", seaweed_filer_endpoint, logger)) as seaweedfs_client, \
+    with closing(SeaweedFSClient("clp—user", seaweed_filer_endpoint, mtls_conf, logger)) as seaweedfs_client, \
             closing(pymongo.MongoClient(db_uri)) as db_client:
     # fmt: on
         archive_db: pymongo.database.Database = db_client.get_default_database()

--- a/src/clp_notification_monitor/seaweedfs_monitor/seaweedfs_grpc_client.py
+++ b/src/clp_notification_monitor/seaweedfs_monitor/seaweedfs_grpc_client.py
@@ -1,8 +1,7 @@
-import os
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Generator, List
-from dataclasses import dataclass
 
 import grpc
 
@@ -20,12 +19,13 @@ from clp_notification_monitor.seaweedfs_monitor.notification_message import (
     SeaweedFID,
 )
 
+
 @dataclass
 class MTLSConfig:
-    Secure: bool           = False
-    ChainPath: Path        = Path("etc/certs/chain.crt")
-    PrivateKeyPath: Path   = Path("etc/certs/private.key")
-    ServerPath: Path       = Path("etc/certs/server.crt")
+    Secure: bool = False
+    ChainPath: Path = Path("etc/certs/chain.crt")
+    PrivateKeyPath: Path = Path("etc/certs/private.key")
+    ServerPath: Path = Path("etc/certs/server.crt")
     SSLTargetOverride: str = ""
 
 
@@ -38,7 +38,9 @@ class SeaweedFSClient(SeaweedFilerServicer):
     the server.
     """
 
-    def __init__(self, client_name: str, endpoint: str, mtls_conf: MTLSConfig, logger: logging.Logger):
+    def __init__(
+        self, client_name: str, endpoint: str, mtls_conf: MTLSConfig, logger: logging.Logger
+    ):
         """
         Constructor.
 
@@ -50,11 +52,13 @@ class SeaweedFSClient(SeaweedFilerServicer):
         self._client_name: str = client_name
         self._channel: grpc.Channel
         if mtls_conf.Secure:
-            server_cert, private_key, certificate_chain = map(lambda x: open(x, 'rb').read(),
-                [mtls_conf.ServerPath, mtls_conf.PrivateKeyPath, mtls_conf.ChainPath])
+            server_cert, private_key, certificate_chain = map(
+                lambda x: open(x, "rb").read(),
+                [mtls_conf.ServerPath, mtls_conf.PrivateKeyPath, mtls_conf.ChainPath],
+            )
             creds = grpc.ssl_channel_credentials(server_cert, private_key, certificate_chain)
             if mtls_conf.SSLTargetOverride != "":
-                options = (('grpc.ssl_target_name_override', mtls_conf.SSLTargetOverride),)
+                options = (("grpc.ssl_target_name_override", mtls_conf.SSLTargetOverride),)
                 self._channel = grpc.secure_channel(endpoint, creds, options=options)
             else:
                 self._channel = grpc.secure_channel(endpoint, creds)

--- a/src/clp_notification_monitor/seaweedfs_monitor/seaweedfs_grpc_client.py
+++ b/src/clp_notification_monitor/seaweedfs_monitor/seaweedfs_grpc_client.py
@@ -1,6 +1,8 @@
+import os
 import logging
 from pathlib import Path
 from typing import Generator, List
+from dataclasses import dataclass
 
 import grpc
 
@@ -18,6 +20,14 @@ from clp_notification_monitor.seaweedfs_monitor.notification_message import (
     SeaweedFID,
 )
 
+@dataclass
+class MTLSConfig:
+    Secure: bool           = False
+    ChainPath: Path        = Path("etc/certs/chain.crt")
+    PrivateKeyPath: Path   = Path("etc/certs/private.key")
+    ServerPath: Path       = Path("etc/certs/server.crt")
+    SSLTargetOverride: str = ""
+
 
 class SeaweedFSClient(SeaweedFilerServicer):
     """
@@ -28,7 +38,7 @@ class SeaweedFSClient(SeaweedFilerServicer):
     the server.
     """
 
-    def __init__(self, client_name: str, endpoint: str, logger: logging.Logger):
+    def __init__(self, client_name: str, endpoint: str, mtls_conf: MTLSConfig, logger: logging.Logger):
         """
         Constructor.
 
@@ -38,7 +48,18 @@ class SeaweedFSClient(SeaweedFilerServicer):
         :param logger: Global logging handler.
         """
         self._client_name: str = client_name
-        self._channel: grpc.Channel = grpc.insecure_channel(endpoint)
+        self._channel: grpc.Channel
+        if mtls_conf.Secure:
+            server_cert, private_key, certificate_chain = map(lambda x: open(x, 'rb').read(),
+                [mtls_conf.ServerPath, mtls_conf.PrivateKeyPath, mtls_conf.ChainPath])
+            creds = grpc.ssl_channel_credentials(server_cert, private_key, certificate_chain)
+            if mtls_conf.SSLTargetOverride != "":
+                options = (('grpc.ssl_target_name_override', mtls_conf.SSLTargetOverride),)
+                self._channel = grpc.secure_channel(endpoint, creds, options=options)
+            else:
+                self._channel = grpc.secure_channel(endpoint, creds)
+        else:
+            self._channel = grpc.insecure_channel(endpoint)
         self._stub: SeaweedFilerStub = SeaweedFilerStub(self._channel)
         self._logger: logging.Logger = logger
 


### PR DESCRIPTION
# Description

If MTLS is enabled in Seaweedfs on grpc ports, notification monitor will need to connect to Seaweedfs over secure channel using the certs provided as arguments.

This change will support this feature.